### PR TITLE
Minor changes within the Launcher branch (but to Drivetrain, primarily)

### DIFF
--- a/src/main/java/frc/robot/core/Robot.java
+++ b/src/main/java/frc/robot/core/Robot.java
@@ -62,6 +62,8 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotPeriodic() {
+      drivetrain.robotPeriodic();
+
       LauncherState state = new LauncherRest();
       state = state.run();
   }
@@ -79,6 +81,8 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void autonomousInit() {
+      drivetrain.autonomousInit();
+
     m_autoSelected = m_chooser.getSelected();
     // autoSelected = SmartDashboard.getString("Auto Selector",
     // defaultAuto);
@@ -90,6 +94,8 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void autonomousPeriodic() {
+      drivetrain.autonomousPeriodic();
+
     switch (m_autoSelected) {
       case kCustomAuto:
         // Put custom auto code here
@@ -114,5 +120,6 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void testPeriodic() {
+    drivetrain.testPeriodic();
   }
 }

--- a/src/main/java/frc/robot/core/utils/Component.java
+++ b/src/main/java/frc/robot/core/utils/Component.java
@@ -2,8 +2,20 @@ package frc.robot.core.utils;
 
 public interface Component {
     default public void robotInit() {}
+    default public void teleopInit() {}
+    default public void autonomousInit() {}
+
 
     default public void teleopPeriodic() {}
-
     default public void autonomousPeriodic() {}
+    default public void testPeriodic() {}
+    /**
+     * This runs after the mode specific periodic functions, but before
+     * LiveWindow and SmartDashboard integrated updating.
+     *
+     * Warning: This is apparently invoked even if the robot is in 
+     * a diabled state.
+     */
+    default public void robotPeriodic() {}
+
 }


### PR DESCRIPTION
I was going to do more in this PR, but I hit numerous "little issues".  For example, I wanted to pull the `LauncherState` classes into a separate package, but was balked by the fact that these use package-private types in `frc.robot.core.components.ControlSystem`.

I could have "fixed" that, of course, but that involves some nontrivial choices that I didn't want to make for you (nor, do I believe, should I be doing so).

So I create some issues instead.  Please feel free to ask any questions about those.

Meanwhile, I'll share this minor evolution of the `Component` and `Drivetrain` entities.  This is probably less about `Drivetrain` (though it should make maintaining and enhancing it easier) and more about other classes that will implement `Component` in the future (ie. `Launcher` - see #3 ).